### PR TITLE
off_heap message queue for Local.Dispatcher

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     name: Build and test
     runs-on: ubuntu-latest
     strategy:
@@ -25,7 +24,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Elixir
-      uses: actions/setup-elixir@v1
+      uses: erlef/setup-beam@v1
       with:
         elixir-version: ${{ matrix.elixir-version }}
         otp-version: ${{ matrix.otp-version }}

--- a/lib/zen_monitor/local/connector.ex
+++ b/lib/zen_monitor/local/connector.ex
@@ -303,7 +303,6 @@ defmodule ZenMonitor.Local.Connector do
   def handle_call({:monitors, target, subscriber}, _from, %State{} = state) do
     size = :ets.info(state.monitors, :size)
 
-
     monitors =
       if size == 0 do
         # Don't bother doing the match on an empty table

--- a/lib/zen_monitor/local/dispatcher.ex
+++ b/lib/zen_monitor/local/dispatcher.ex
@@ -102,6 +102,7 @@ defmodule ZenMonitor.Local.Dispatcher do
   ## Server
 
   def init(_opts) do
+    Process.flag(:message_queue_data, :off_heap)
     {:consumer, nil, subscribe_to: [{ZenMonitor.Local, min_demand: 1}]}
   end
 

--- a/test/black_box_test.exs
+++ b/test/black_box_test.exs
@@ -476,7 +476,6 @@ defmodule ZenMonitor.BlackBox.Test do
       other_ref_b = ZenMonitor.monitor(other)
       Helper.await_monitors_established([other_ref_a, other_ref_b], other)
 
-
       # Kill other after establishing the monitors
       Process.exit(other, :kill)
       Helper.await_monitors_cleared([other_ref_a, other_ref_b], other)
@@ -673,7 +672,6 @@ defmodule ZenMonitor.BlackBox.Test do
       # Kill the remote process
       Process.exit(target, :kill)
       Helper.await_monitor_cleared(ref_to_keep, target)
-
 
       # Assert that the monitor that was not demonitored fired
       assert_receive {:DOWN, ^ref_to_keep, :process, ^target, {:zen_monitor, _}}


### PR DESCRIPTION
This matches the behavior of ZenMonitor.Local and ZenMonitor.Proxy, which are the other two singletons that all of the down notices / certificates pass through.