### PR TITLE
[zen_monitor] Make ZenMonitor.Truncate robust to unknown structs

### DIFF
--- a/lib/zen_monitor/truncator.ex
+++ b/lib/zen_monitor/truncator.ex
@@ -184,7 +184,7 @@ defmodule ZenMonitor.Truncator do
       |> Map.from_struct()
       |> do_truncate(current, max_depth)
 
-    if is_map(truncated_value) do
+    if is_map(truncated_value) and function_exported?(struct_module, :__struct__, 0) do
       struct(struct_module, truncated_value)
     else
       truncated_value

--- a/lib/zen_monitor/truncator.ex
+++ b/lib/zen_monitor/truncator.ex
@@ -184,8 +184,10 @@ defmodule ZenMonitor.Truncator do
       |> Map.from_struct()
       |> do_truncate(current, max_depth)
 
-    if is_map(truncated_value) and function_exported?(struct_module, :__struct__, 0) do
-      struct(struct_module, truncated_value)
+    if is_map(truncated_value) do
+      # Don't use Kernel.struct/2 because that crashes if this node
+      # does not have the code for struct_module.
+      Map.put(truncated_value, :__struct__, struct_module)
     else
       truncated_value
     end

--- a/test/truncator_test.exs
+++ b/test/truncator_test.exs
@@ -152,6 +152,31 @@ defmodule TruncatorTest do
     end
   end
 
+  describe "struct robustness" do
+    test "small unknown struct loses its struct key" do
+      unknown_struct = %{
+        :__struct__ => NotARealModule,
+        a: :b,
+        c: :d
+      }
+
+      assert %{a: :b, c: :d} == Truncator.truncate(unknown_struct)
+    end
+
+    test "large unknown struct should be truncated" do
+      unknown_struct = %{
+        :__struct__ => NotARealModule,
+        a: :b,
+        c: :d,
+        e: :f,
+        g: :h,
+        i: :j,
+      }
+
+      assert :truncated == Truncator.truncate(unknown_struct)
+    end
+  end
+
   describe "limited nesting" do
     defmodule Nested do
       defstruct map: %{},

--- a/test/truncator_test.exs
+++ b/test/truncator_test.exs
@@ -153,14 +153,14 @@ defmodule TruncatorTest do
   end
 
   describe "struct robustness" do
-    test "small unknown struct loses its struct key" do
+    test "small unknown struct stays as-is" do
       unknown_struct = %{
         :__struct__ => NotARealModule,
         a: :b,
         c: :d
       }
 
-      assert %{a: :b, c: :d} == Truncator.truncate(unknown_struct)
+      assert unknown_struct == Truncator.truncate(unknown_struct)
     end
 
     test "large unknown struct should be truncated" do


### PR DESCRIPTION
Previously, trying to truncate a small struct which is not defined on the node experiencing a crash would result in ZenMonitor.Proxy crashing, which means that all remote monitors would assume that every process on the node with such a poison crash had died. This avoids trying to call Kernel.struct on modules we don't think have structs.

The crash observed looked like this:
```
GenServer ZenMonitor.Proxy terminating
** (UndefinedFunctionError) function ThisModuleDoesNotExist.__struct__/0 is undefined (module ThisModuleDoesNotExist is not available)
    ThisModuleDoesNotExist.__struct__()
    (elixir 1.12.2) lib/kernel.ex:2303: Kernel.struct/3
    (zen_monitor 2.0.2) lib/zen_monitor/truncator.ex:196: anonymous fn/4 in ZenMonitor.Truncator.do_truncate/3
```