### PR TITLE
Add the ability to configure timeout for Batcher

### DIFF
--- a/lib/zen_monitor.ex
+++ b/lib/zen_monitor.ex
@@ -124,7 +124,7 @@ defmodule ZenMonitor do
   """
   @spec now() :: integer
   def now do
-    System.monotonic_time(:milliseconds)
+    System.monotonic_time(:millisecond)
   end
 
   @doc """


### PR DESCRIPTION
New configuration value `{:zen_monitor, :batcher_lookup_timeout}` that defaults to 30s.

The Proxy process going down is a relatively big deal, all other nodes will treat this like a node down.  Going down because Proxy can not enqueue a down message with a Batcher is a bit extreme.

This change provides a bit more slack for getting a Batcher (30s vs 5s) and provides a facility for the end user to configure this value.